### PR TITLE
completed side-nave styling

### DIFF
--- a/src/components/SideNav/SideNav.css
+++ b/src/components/SideNav/SideNav.css
@@ -1,5 +1,34 @@
 
+
 .side-nav-list {
-    list-style: none;
-    padding-left: .5rem;
+  list-style: none;
+  font-family: 'Open Sans', sans-serif;
+  padding: 0px;
+  margin-top: 35px;
+}
+
+
+/* spacing, and bold when selected
+:active
+option to be active
+*/
+.side-nav-list>li {
+  display: flex;
+  height: 40px;
+  padding: 9px 107px 7px 16px;
+  margin-right: 16px;
+  align-items: center;
+  flex-shrink: 0;
+  align-self: stretch;
+}
+
+.side-nav-list li:hover {
+  background-color: rgba(0, 94, 131, 0.10);
+  border-radius: 5px;
+  display: flex;
+  height: 40px;
+  padding: 9px 107px 7px 16px;
+  align-items: center;
+  flex-shrink: 0;
+  align-self: stretch;
 }


### PR DESCRIPTION
.side-nav-list 
font family open sans, and sans-serif. I adding a padding of 0px because this allowed the li to somehow be aligned correctly otherwise. I added a margin-top of 35px so that the top of the home li is flush with the top of the white div to its right

.side-nav-list > li 
margin-right of 16px permitted what looks like the proper spacing for the li when hover is active on that item

li:hover 
has the correct color pulled from figma